### PR TITLE
Make URL cleaning work again for Google domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -285,7 +285,7 @@ function getMatch(gbp, domain, rootDomain, domainMinusSuffix, detailsUrl){
 	}
 
 	// Workaround for https://github.com/Smile4ever/firefoxaddons/issues/76
-	if (gbp == "gws_rd@google.*" && rootDomain == "google.com" && detailsUrl.contains("gws_rd=cr")){
+	if (gbp == "gws_rd@google.*" && rootDomain == "google.com" && detailsUrl.searchParams.get("gws_rd") == "cr"){
 		return;
 	}
 


### PR DESCRIPTION
This PR corrects the syntax used to look for the special case `gws_rd=cr` in the URL (if I got it right), and should fix https://github.com/Smile4ever/Neat-URL/issues/151 as a `TypeError` is no longer raised.

For example, the example URL from https://github.com/Smile4ever/Neat-URL/issues/146: `https://www.google.com/search?tbm=isch&sa=1&ei=oCElW5eAGaeJmgXR37HADA&q=weird+stuff&oq=weird+stuff&gs_l=img.12...0.0.0.36804.0.0.0.0.0.0.0.0..0.0....0...1c..64.img..0.0.0....0.22LdBvL5qXs`, is now correctly redirected to `https://www.google.com/search?tbm=isch&sa=1&q=weird+stuff&oq=weird+stuff` without the need to change the default blocked parameters.

Anyway I am not very clear about the original code and the problem it tries to fix. Could you explain how did https://github.com/Smile4ever/Neat-URL/issues/76 happen and why this check solves it?