### PR TITLE
block ref_*@twitter.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Neat URL is a browser extension that cleans URLs, removing parameters such as Go
         { "name": "Google", "params": ["gs_l", "gs_lcp@google.*", "ved@google.*", "ei@google.*", "sei@google.*", "gws_rd@google.*", "gs_gbg@google.*", "gs_mss@google.*", "gs_rn@google.*"]},
         { "name": "Hubspot", "params": ["_hsenc", "_hsmi", "__hssc", "__hstc", "hsCtaTracking"]},
         { "name": "SourceForge.net", "params": ["source@sourceforge.net", "position@sourceforge.net"]},
-        { "name": "Twitter", "params": ["t@twitter.com", "s@twitter.com"]},
+        { "name": "Twitter", "params": ["t@twitter.com", "s@twitter.com", "ref_*@twitter.com"]},
         { "name": "Twitch.tv", "params": ["tt_medium", "tt_content"]},
         { "name": "Yandex", "params": ["lr@yandex.*", "redircnt@yandex.*"]},
         { "name": "YouTube.com", "params": ["feature@youtube.com", "kw@youtube.com"]},

--- a/data/default-params-by-category.json
+++ b/data/default-params-by-category.json
@@ -26,7 +26,7 @@
         { "name": "Google", "params": ["gs_l", "gs_lcp@google.*", "ved@google.*", "ei@google.*", "sei@google.*", "gws_rd@google.*", "gs_gbg@google.*", "gs_mss@google.*", "gs_rn@google.*"]},
         { "name": "Hubspot", "params": ["_hsenc", "_hsmi", "__hssc", "__hstc", "hsCtaTracking"]},
         { "name": "SourceForge.net", "params": ["source@sourceforge.net", "position@sourceforge.net"]},
-        { "name": "Twitter", "params": ["t@twitter.com", "s@twitter.com"]},
+        { "name": "Twitter", "params": ["t@twitter.com", "s@twitter.com", "ref_*@twitter.com"]},
         { "name": "Twitch.tv", "params": ["tt_medium", "tt_content"]},
         { "name": "Yandex", "params": ["lr@yandex.*", "redircnt@yandex.*"]},
         { "name": "YouTube.com", "params": ["feature@youtube.com", "kw@youtube.com"]},


### PR DESCRIPTION
PR for https://github.com/Smile4ever/Neat-URL/issues/237#issuecomment-1016277260

Verified that this structure exists in embedded links: https://twitter.com/DanielSolis/status/1487913576929103884?ref_src=twsrc^tfw|twcamp^tweetembed|twterm^1487913576929103884|twgr^|twcon^s1_&ref_url=https%3A%2F%2Fwww.dailykos.com%2Fstory%2F2022%2F1%2F31%2F2077753%2F-New-Day-Cafe-These-Birds-Do-Not-Exist